### PR TITLE
feat: Add script to disable default zoom in popup body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+## [0.6.1] 2024-05-05
+- Added JavaScript snippet to disable default zoom behavior in popup body when Ctrl key is pressed during scrolling.
+
 ## [0.6.0] 2024-05-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="icons/ext-icon-64.png" alt="LinkQR icon">
     <h1>LinkQR</h1>
 	
-[![Extension Version](https://img.shields.io/badge/Version-0.6.0-blue)](https://github.com/xKe00/LinkQR/blob/main/manifest.json) [![License](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
+[![Extension Version](https://img.shields.io/badge/Version-0.6.1-blue)](https://github.com/xKe00/LinkQR/blob/main/manifest.json) [![License](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
 
 [Changelog](./CHANGELOG.md)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "LinkQR",
-  "version": "0.6.0",
+  "version": "0.6.1",
 
   "description": "Converts web links into QR codes with a single click from the address bar. Copy or download QR codes in PNG/SVG format for sharing.",
   "homepage_url": "https://github.com/xke00/linkqr/main",

--- a/popup/app.js
+++ b/popup/app.js
@@ -113,3 +113,19 @@ $text.addEventListener("input", function () {
 $text.addEventListener("focus", function () {
     this.select();
 });
+
+// This script disables the default zoom behavior in the popup body when the Ctrl key is pressed during scrolling
+document.addEventListener('DOMContentLoaded', function() {
+    // Select the popup body element
+    var popupBody = document.querySelector('.popup-body');
+  
+    // Add a wheel event listener to the popup body
+    popupBody.addEventListener('wheel', function(event) {
+      // Check if the Ctrl key is pressed
+      if (event.ctrlKey) {
+        // If Ctrl key is pressed, prevent the default zoom behavior
+        event.preventDefault();
+      }
+    });
+  });
+  


### PR DESCRIPTION
Prevents default zoom behaviour in popup body when Ctrl key is pressed during scrolling by adding a JavaScript snippet in 'app.js'